### PR TITLE
Do not share session IDs between peers

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -336,6 +336,9 @@ func (ws *WebsocketSession) onPeerEvent(message []byte) error {
 		return nil
 	}
 
+	// Blank out session token so peers can't impersonate each other.
+	peer.Session = ""
+
 	bytes, err := json.Marshal(peer)
 
 	if err != nil {


### PR DESCRIPTION
Peers could impersonate each other otherwise.

Helping clients uniquely identify peers isn't a design goal right now.