### PR TITLE
Tracing cleanup

### DIFF
--- a/app.go
+++ b/app.go
@@ -26,7 +26,7 @@ type Event struct {
 	Kind    string `json:"kind,omitempty"`
 }
 
-func GenerateSessionId(ctx context.Context) string {
+func GenerateSessionId(ctx context.Context) (string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "GenerateSessionId")
 	defer span.Finish()
 
@@ -34,10 +34,10 @@ func GenerateSessionId(ctx context.Context) string {
 
 	if err != nil {
 		ext.LogError(span, err)
-		return ""
+		return "", err
 	}
 
-	return id.String()
+	return id.String(), nil
 }
 
 func ParseSessionId(ctx context.Context, id string) bool {

--- a/app.go
+++ b/app.go
@@ -5,8 +5,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/segmentio/ksuid"
-	"net/http"
-	"strings"
 )
 
 const MessageKindJoin = "JOIN"
@@ -51,17 +49,4 @@ func ParseSessionId(ctx context.Context, id string) bool {
 	}
 
 	return true
-}
-
-func ExtractCallId(ctx context.Context, r *http.Request) string {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExtractCallId")
-	defer span.Finish()
-
-	segments := strings.Split(strings.TrimPrefix(strings.TrimSuffix(r.URL.Path, "/"), "/"), "/")
-
-	if len(segments) >= 2 {
-		return segments[1]
-	}
-
-	return ""
 }

--- a/publisher.go
+++ b/publisher.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 var ErrPublisher = errors.New("publisher client error")
@@ -28,7 +28,7 @@ func (r *RedisPublisher) Publish(ctx context.Context, topic string, event interf
 	defer span.Finish()
 
 	if topic == "" {
-		span.LogFields(log.String("info", "empty topic"))
+		ext.LogError(span, fmt.Errorf("empty topic"))
 		return ErrPublisher
 	}
 

--- a/seat.go
+++ b/seat.go
@@ -6,6 +6,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"net/http"
+	"strings"
 )
 
 type SeatHandler struct {
@@ -22,9 +23,13 @@ func (sh *SeatHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	span, ctx := opentracing.StartSpanFromContext(r.Context(), "SeatHandler.ServeHTTP")
 	defer span.Finish()
 
-	call := ExtractCallId(ctx, r)
+	var call string
 
-	if call == "" {
+	segments := strings.Split(strings.TrimPrefix(strings.TrimSuffix(r.URL.Path, "/"), "/"), "/")
+
+	if len(segments) == 2 && segments[1] != "" {
+		call = segments[1]
+	} else {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}

--- a/seat_test.go
+++ b/seat_test.go
@@ -85,6 +85,16 @@ func (suite *SeatHandlerTestSuite) TestSeatHandler_ServeHTTP_NoCall() {
 	suite.Equal(404, w.Result().StatusCode)
 }
 
+// Validate that we return a 404 to the client when they request an invalid path.
+func (suite *SeatHandlerTestSuite) TestSeatHandler_ServeHTTP_InvalidPath() {
+	req := httptest.NewRequest("GET", "http://localhost/call/12345/extra", nil)
+	w := httptest.NewRecorder()
+
+	suite.Handler.ServeHTTP(w, req)
+
+	suite.Equal(404, w.Result().StatusCode)
+}
+
 // Validate that we return a 409 to the client when no seats are available.
 func (suite *SeatHandlerTestSuite) TestSeatHandler_ServeHTTP_NoSeatAvailable() {
 	suite.Lock.On("Acquire", mock.Anything, suite.Call, suite.Session).Return(

--- a/seat_test.go
+++ b/seat_test.go
@@ -30,7 +30,7 @@ func (suite *SeatHandlerTestSuite) SetupTest() {
 	suite.URL = "http://localhost/call/" + suite.Call
 
 	suite.Handler = &SeatHandler{
-		Generator: func(_ context.Context) string { return suite.Session },
+		Generator: func(_ context.Context) (string, error) { return suite.Session, nil },
 		Lock:      suite.Lock,
 		Publisher: suite.Publisher,
 	}

--- a/semaphore.go
+++ b/semaphore.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"io"
@@ -86,6 +87,7 @@ func (r *RedisSemaphore) Acquire(ctx context.Context, name string, id string) (b
 	defer span.Finish()
 
 	if name == "" || id == "" {
+		ext.LogError(span, fmt.Errorf("empty semaphore name or id"))
 		return false, ErrSemaphore
 	}
 
@@ -112,6 +114,7 @@ func (r *RedisSemaphore) Check(ctx context.Context, name string, id string) (boo
 	defer span.Finish()
 
 	if name == "" || id == "" {
+		ext.LogError(span, fmt.Errorf("empty semaphore name or id"))
 		return false, ErrSemaphore
 	}
 
@@ -134,6 +137,7 @@ func (r *RedisSemaphore) Release(ctx context.Context, name string, id string) er
 	defer span.Finish()
 
 	if name == "" || id == "" {
+		ext.LogError(span, fmt.Errorf("empty semaphore name or id"))
 		return ErrSemaphore
 	}
 

--- a/websocket.go
+++ b/websocket.go
@@ -102,7 +102,7 @@ func (ws *WebsocketSession) Start() {
 	err = json.Unmarshal(message, &join)
 
 	if err != nil {
-		span.LogFields(log.String("close", err.Error()))
+		span.LogFields(log.Message("closing connection on malformed handshake"))
 		_ = ws.close("bad handshake")
 		return
 	}
@@ -110,7 +110,7 @@ func (ws *WebsocketSession) Start() {
 	valid := ValidateClientHandshake(ctx, join)
 
 	if !valid {
-		span.LogFields(log.String("close", "bad handshake"))
+		span.LogFields(log.Message("closing connection on bad handshake"))
 		_ = ws.close("bad handshake")
 		return
 	}
@@ -129,7 +129,7 @@ func (ws *WebsocketSession) Start() {
 	}
 
 	if !held {
-		span.LogFields(log.String("close", "lock not held"))
+		span.LogFields(log.Message("closing connection on expired or invalid session id"))
 		_ = ws.close("bad seat")
 		return
 	}
@@ -315,7 +315,7 @@ func (ws *WebsocketSession) onPeerEvent(message []byte) error {
 	valid := ValidatePeerEvent(ctx, ws.call, peer)
 
 	if !valid {
-		span.LogFields(log.String("skip", "invalid event"))
+		span.LogFields(log.Message("aborted on invalid event"))
 		return nil
 	}
 
@@ -332,7 +332,7 @@ func (ws *WebsocketSession) onPeerEvent(message []byte) error {
 
 	// Don't send echo'd messages back to clients.
 	if peer.Session == ws.session {
-		span.LogFields(log.String("skip", "echo event"))
+		span.LogFields(log.Message("aborted on echo"))
 		return nil
 	}
 


### PR DESCRIPTION
1. Use common format for log messages.
2. Start recording errors where they occur.